### PR TITLE
new(ci): add a weekly workflow to sync vmlinux and api headers from upstream

### DIFF
--- a/.github/workflows/sync-api-vmlinux.yaml.yml
+++ b/.github/workflows/sync-api-vmlinux.yaml.yml
@@ -1,0 +1,115 @@
+name: Sync api.h and vmlinux.h from latest kernel
+on:
+  workflow_dispatch:
+    inputs:
+      linux-release:
+        description: 'Linux kernel release to run against'
+        required: false
+        type: string
+  schedule:
+    - cron: '0 2 * * 1' # each monday at 2:00
+
+jobs:
+  load-latest-kernel-release:
+    runs-on: 'ubuntu-24.04'
+    outputs:
+      release: steps.kernel-fixed.outputs.release
+    steps:
+      - uses: pozetroninc/github-action-get-latest-release@2a61c339ea7ef0a336d1daa35ef0cb1418e7676c # v0.8.0
+        id: kernel
+        if: inputs.linux-release == ''
+        with:
+          owner: torvalds
+          repo: linux
+          excludes: prerelease, draft
+
+      - name: only account for non-rc tags
+        id: kernel-fixed
+        run: |
+          ktag=${{ inputs.linux-release }}
+          if [[ -z "${ktag}" ]]; then
+            ktag=${{ steps.kernel.outputs.release }}
+            echo "using latest linux release: ${ktag}"
+          else
+            echo "enforcing requested linux release: ${ktag}"
+          fi
+          if [[ "${ktag}" =~ "*-rc*" ]]; then
+            echo "Skipping job execution for RC: ${ktag}."
+          else
+            echo "release=${ktag}" >> "$GITHUB_OUTPUT"
+          fi
+
+  sync-api-vmlinux:
+    needs: load-latest-kernel-release
+    if: needs.load-latest-kernel-release.outputs.release != ''
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
+    strategy:
+      matrix:
+        arch: [ x86, arm64 ]
+    steps:
+      - name: Install bpftool
+        uses: mtardy/setup-bpftool@9bc044304197616a6321d452e04cc059e006d8e2 # v1.0.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install virtme-ng
+        run: sudo apt update && sudo apt install --yes virtme-ng
+
+      - name: Run virtme-ng against latest kernel and generate vmlinux
+        run: |
+          vng -r ${{ needs.load-latest-kernel-release.outputs.release }} --rw
+          mkdir out
+          bpftool btf dump file /sys/kernel/btf/vmlinux format c > out/vmlinux_generated_${{ matrix.arch }}.h
+
+      - name: Generate api.h (x86 only)
+        if: matrix.arch == 'x86'
+        run: |
+          # todo generate api.h
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sync_${{ matrix.arch }}
+          path: 'out/*.h'
+          if-no-files-found: error
+
+  create-pr:
+    needs: [load-latest-kernel-release, sync-api-vmlinux]
+    if: needs.load-latest-kernel-release.outputs.release != ''
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: 'ubuntu-24.04'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+
+      - name: Download x86 artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: sync_x86
+          path: bpf/include/
+
+      - name: Download arm64 artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: sync_arm64
+          path: bpf/include/
+
+      # In case of no diff, this won't create any PR.
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          signoff: true
+          base: main
+          branch: sync/bpf_headers
+          title: 'sync(bpf): update bpf api and vmlinux_generated headers'
+          body: |
+            This automatic PR syncs bpf api and vmlinux_generated headers from latest kernel. Do not edit this PR.
+            ```release-note
+            NONE
+            ```
+          commit-message: 'sync(bpf): update bpf api and vmlinux_generated headers.'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It will create a PR with the proposed changes.
When automatically ran, it only runs for non-rc releases. When manually ran, you can optionally specify a linux release version to run against.
